### PR TITLE
Added softlink for the files in bin folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,5 +106,12 @@ install(TARGETS ${HIPCC_BIN}
 install(TARGETS ${HIPCONFIG_BIN}
   COMPONENT ${hipcc_NAME}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+# TODO: WIN32 check need to be removed if backward compatibility is required for WIN32
+option(HIPCC_BACKWARD_COMPATIBILITY "Enable HIPCC backward compatibility" ON)
+if(NOT WIN32)
+    if(HIPCC_BACKWARD_COMPATIBILITY)
+        include(hipcc-backward-compat.cmake)
+    endif()
+endif()
 
 include(CPack)

--- a/hipcc-backward-compat.cmake
+++ b/hipcc-backward-compat.cmake
@@ -1,0 +1,42 @@
+# Copyright (c) 2022 Advanced Micro Devices, Inc. All Rights Reserved.
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+cmake_minimum_required(VERSION 3.16.8)
+
+set(HIPCC_WRAPPER_BIN_DIR ${CMAKE_CURRENT_BINARY_DIR}/wrapper_dir/bin)
+set(HIPCC_SRC_BIN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+
+#function to create symlink to binaries
+function(create_binary_symlink)
+  file(MAKE_DIRECTORY ${HIPCC_WRAPPER_BIN_DIR})
+  #get all  binaries
+  file(GLOB binary_files ${HIPCC_SRC_BIN_DIR}/*)
+  foreach(binary_file ${binary_files})
+    get_filename_component(file_name ${binary_file} NAME)
+    add_custom_target(link_${file_name} ALL
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                  COMMAND ${CMAKE_COMMAND} -E create_symlink
+                  ../../${CMAKE_INSTALL_BINDIR}/${file_name} ${HIPCC_WRAPPER_BIN_DIR}/${file_name})
+  endforeach()
+endfunction()
+
+# Create symlink to binaries
+create_binary_symlink()
+# TODO: Following has to modified if component based installation is required
+install(DIRECTORY ${HIPCC_WRAPPER_BIN_DIR} DESTINATION hip)


### PR DESCRIPTION
The HIPCC binary files will be installed in bin directory 
For backward compatibility, the hip/bin folder will have soft links to the actual files